### PR TITLE
Centralized shared Stan functions in utilities.stan

### DIFF
--- a/gloria/models.py
+++ b/gloria/models.py
@@ -414,10 +414,12 @@ class ModelBackendBase(ABC):
         cmdstan_path = models_path / f"cmdstan-{_CMDSTAN_VERSION}"
         set_cmdstan_path(str(cmdstan_path))
         # Initialize the Stan model
-        self.model = CmdStanModel(
-            stan_file=self.stan_file,  # Keep explicit stan_file for dev
-            exe_file=self.stan_file.with_suffix(".exe"),
-        )
+        exe_file = self.stan_file.with_suffix(".exe")
+        if exe_file.exists():
+            self.model = CmdStanModel(exe_file=exe_file)
+        else:
+            # for dev deleting the exe file triggers compiliation
+            self.model = CmdStanModel(stan_file=self.stan_file)
         # Silence cmdstanpy logger
         stan_logger = logging.getLogger("cmdstanpy")
         stan_logger.setLevel(logging.CRITICAL)

--- a/gloria/stan_models/beta.stan
+++ b/gloria/stan_models/beta.stan
@@ -3,41 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-functions {
-  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
-    // Assumes t and t_change are sorted.
-    matrix[T, S] A;
-    row_vector[S] a_row;
-    int cp_idx;
-
-    // Start with an empty matrix.
-    A = rep_matrix(0, T, S);
-    a_row = rep_row_vector(0, S);
-    cp_idx = 1;
-
-    // Fill in each row of A.
-    for (i in 1:T) {
-      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
-        a_row[cp_idx] = 1;
-        cp_idx = cp_idx + 1;
-      }
-      A[i] = a_row;
-    }
-    return A;
-  }
-  
-  // Linear trend function
-  vector linear_trend(
-    real k,
-    real m,
-    vector delta,
-    vector t,
-    matrix A,
-    vector t_change
-  ) {
-    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
-  }
-}
+#include utilities.stan
 
 data {
   int<lower=0> T;               // Number of time periods

--- a/gloria/stan_models/beta_binomial.stan
+++ b/gloria/stan_models/beta_binomial.stan
@@ -3,41 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-functions {
-  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
-    // Assumes t and t_change are sorted.
-    matrix[T, S] A;
-    row_vector[S] a_row;
-    int cp_idx;
-
-    // Start with an empty matrix.
-    A = rep_matrix(0, T, S);
-    a_row = rep_row_vector(0, S);
-    cp_idx = 1;
-
-    // Fill in each row of A.
-    for (i in 1:T) {
-      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
-        a_row[cp_idx] = 1;
-        cp_idx = cp_idx + 1;
-      }
-      A[i] = a_row;
-    }
-    return A;
-  }
-  
-  // Linear trend function
-  vector linear_trend(
-    real k,
-    real m,
-    vector delta,
-    vector t,
-    matrix A,
-    vector t_change
-  ) {
-    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
-  }
-}
+#include utilities.stan
 
 data {
   int<lower=0> T;               // Number of time periods

--- a/gloria/stan_models/binomial.stan
+++ b/gloria/stan_models/binomial.stan
@@ -3,41 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-functions {
-  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
-    // Assumes t and t_change are sorted.
-    matrix[T, S] A;
-    row_vector[S] a_row;
-    int cp_idx;
-
-    // Start with an empty matrix.
-    A = rep_matrix(0, T, S);
-    a_row = rep_row_vector(0, S);
-    cp_idx = 1;
-
-    // Fill in each row of A.
-    for (i in 1:T) {
-      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
-        a_row[cp_idx] = 1;
-        cp_idx = cp_idx + 1;
-      }
-      A[i] = a_row;
-    }
-    return A;
-  }
-  
-  // Linear trend function
-  vector linear_trend(
-    real k,
-    real m,
-    vector delta,
-    vector t,
-    matrix A,
-    vector t_change
-  ) {
-    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
-  }
-}
+#include utilities.stan
 
 data {
   int<lower=0> T;               // Number of time periods

--- a/gloria/stan_models/gamma.stan
+++ b/gloria/stan_models/gamma.stan
@@ -3,41 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-functions {
-  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
-    // Assumes t and t_change are sorted.
-    matrix[T, S] A;
-    row_vector[S] a_row;
-    int cp_idx;
-
-    // Start with an empty matrix.
-    A = rep_matrix(0, T, S);
-    a_row = rep_row_vector(0, S);
-    cp_idx = 1;
-
-    // Fill in each row of A.
-    for (i in 1:T) {
-      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
-        a_row[cp_idx] = 1;
-        cp_idx = cp_idx + 1;
-      }
-      A[i] = a_row;
-    }
-    return A;
-  }
-  
-  // Linear trend function
-  vector linear_trend(
-    real k,
-    real m,
-    vector delta,
-    vector t,
-    matrix A,
-    vector t_change
-  ) {
-    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
-  }
-}
+#include utilities.stan
 
 data {
   int<lower=0> T;               // Number of time periods

--- a/gloria/stan_models/negative_binomial.stan
+++ b/gloria/stan_models/negative_binomial.stan
@@ -3,41 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-functions {
-  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
-    // Assumes t and t_change are sorted.
-    matrix[T, S] A;
-    row_vector[S] a_row;
-    int cp_idx;
-
-    // Start with an empty matrix.
-    A = rep_matrix(0, T, S);
-    a_row = rep_row_vector(0, S);
-    cp_idx = 1;
-
-    // Fill in each row of A.
-    for (i in 1:T) {
-      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
-        a_row[cp_idx] = 1;
-        cp_idx = cp_idx + 1;
-      }
-      A[i] = a_row;
-    }
-    return A;
-  }
-  
-  // Linear trend function
-  vector linear_trend(
-    real k,
-    real m,
-    vector delta,
-    vector t,
-    matrix A,
-    vector t_change
-  ) {
-    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
-  }
-}
+#include utilities.stan
 
 data {
   int<lower=0> T;               // Number of time periods

--- a/gloria/stan_models/normal.stan
+++ b/gloria/stan_models/normal.stan
@@ -3,41 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-functions {
-  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
-    // Assumes t and t_change are sorted.
-    matrix[T, S] A;
-    row_vector[S] a_row;
-    int cp_idx;
-
-    // Start with an empty matrix.
-    A = rep_matrix(0, T, S);
-    a_row = rep_row_vector(0, S);
-    cp_idx = 1;
-
-    // Fill in each row of A.
-    for (i in 1:T) {
-      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
-        a_row[cp_idx] = 1;
-        cp_idx = cp_idx + 1;
-      }
-      A[i] = a_row;
-    }
-    return A;
-  }
-  
-  // Linear trend function
-  vector linear_trend(
-    real k,
-    real m,
-    vector delta,
-    vector t,
-    matrix A,
-    vector t_change
-  ) {
-    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
-  }
-}
+#include utilities.stan
 
 data {
   int<lower=0> T;               // Number of time periods

--- a/gloria/stan_models/poisson.stan
+++ b/gloria/stan_models/poisson.stan
@@ -3,41 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-functions {
-  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
-    // Assumes t and t_change are sorted.
-    matrix[T, S] A;
-    row_vector[S] a_row;
-    int cp_idx;
-
-    // Start with an empty matrix.
-    A = rep_matrix(0, T, S);
-    a_row = rep_row_vector(0, S);
-    cp_idx = 1;
-
-    // Fill in each row of A.
-    for (i in 1:T) {
-      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
-        a_row[cp_idx] = 1;
-        cp_idx = cp_idx + 1;
-      }
-      A[i] = a_row;
-    }
-    return A;
-  }
-  
-  // Linear trend function
-  vector linear_trend(
-    real k,
-    real m,
-    vector delta,
-    vector t,
-    matrix A,
-    vector t_change
-  ) {
-    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
-  }
-}
+#include utilities.stan
 
 data {
   int<lower=0> T;               // Number of time periods

--- a/gloria/stan_models/utilities.stan
+++ b/gloria/stan_models/utilities.stan
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 e-dynamics GmbH and affiliates
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+functions {
+  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
+    // Assumes t and t_change are sorted.
+    matrix[T, S] A;
+    row_vector[S] a_row;
+    int cp_idx;
+
+    // Start with an empty matrix.
+    A = rep_matrix(0, T, S);
+    a_row = rep_row_vector(0, S);
+    cp_idx = 1;
+
+    // Fill in each row of A.
+    for (i in 1:T) {
+      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
+        a_row[cp_idx] = 1;
+        cp_idx = cp_idx + 1;
+      }
+      A[i] = a_row;
+    }
+    return A;
+  }
+  
+  // Linear trend function
+  vector linear_trend(
+    real k,
+    real m,
+    vector delta,
+    vector t,
+    matrix A,
+    vector t_change
+  ) {
+    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
+  }
+}


### PR DESCRIPTION
The two functions ``get_changepoint_matrix()`` and ``linear_trend()`` were used by all Stan models and were therefore moved into the importable ``utilities.stan`` file.

This PR resolves #99 