### PR TITLE
Enh #98 remove bounds on parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-gloria/stan_models/*
-!gloria/stan_models/*.stan
-!gloria/stan_models/utilities/*.stan
+gloria/stan_models/cmdstan*
+gloria/stan_models/*.exe
 **/__pycache__
 **/logfiles/
 **/models

--- a/gloria/stan_models/utilities/data.stan
+++ b/gloria/stan_models/utilities/data.stan
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 e-dynamics GmbH and affiliates
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Input data shared by all models
+int<lower=0> T;               // Number of time periods
+int<lower=0> S;               // Number of changepoints
+int<lower=0> K;               // Number of regressors
+real<lower=0> tau;            // Scale on changepoints prior
+vector[T] t;                  // Time as integer vector
+vector[S] t_change;           // Times of trend changepoints as integers
+matrix[T,K] X;                // Regressors
+vector[K] sigmas;             // Scale on seasonality prior
+real linked_offset;           // Offset of linear model
+real linked_scale;            // Scale of linear model

--- a/gloria/stan_models/utilities/functions.stan
+++ b/gloria/stan_models/utilities/functions.stan
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 e-dynamics GmbH and affiliates
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+functions {
+  matrix get_changepoint_matrix(vector t, vector t_change, int T, int S) {
+    // Assumes t and t_change are sorted.
+    matrix[T, S] A;
+    row_vector[S] a_row;
+    int cp_idx;
+
+    // Start with an empty matrix.
+    A = rep_matrix(0, T, S);
+    a_row = rep_row_vector(0, S);
+    cp_idx = 1;
+
+    // Fill in each row of A.
+    for (i in 1:T) {
+      while ((cp_idx <= S) && (t[i] >= t_change[cp_idx])) {
+        a_row[cp_idx] = 1;
+        cp_idx = cp_idx + 1;
+      }
+      A[i] = a_row;
+    }
+    return A;
+  }
+  
+  // Linear trend function
+  vector linear_trend(
+    real k,
+    real m,
+    vector delta,
+    vector t,
+    matrix A,
+    vector t_change
+  ) {
+    return (k + A * delta) .* t + (m + A * (-t_change .* delta));
+  }
+}

--- a/gloria/stan_models/utilities/parameters.stan
+++ b/gloria/stan_models/utilities/parameters.stan
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 e-dynamics GmbH and affiliates
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Model parameters shared by all models
+real<lower=-0.5, upper=0.5> k;        // Base trend growth rate
+real<lower=0, upper=1> m;             // Trend offset
+vector<lower=-1, upper=1>[S] delta;   // Trend rate adjustments
+vector[K] beta;                       // Regressor coefficients

--- a/gloria/stan_models/utilities/priors.stan
+++ b/gloria/stan_models/utilities/priors.stan
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 e-dynamics GmbH and affiliates
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+
+// Priors shared by all models
+k ~ normal(0,0.5);
+m ~ normal(0.5,0.5);
+delta ~ double_exponential(0, delta_scale);
+beta ~ normal(0, beta_scale);

--- a/gloria/stan_models/utilities/transformed_data.stan
+++ b/gloria/stan_models/utilities/transformed_data.stan
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 e-dynamics GmbH and affiliates
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+
+// Data transformations shared by all models
+
+matrix[T, S] A = get_changepoint_matrix(t, t_change, T, S);
+
+// Find regressor-wise scales
+vector[K] reg_scales;
+for (j in 1:K) {
+  reg_scales[j] = max(X[, j]) - min(X[, j]);
+}
+
+// Scaling factor for beta-prior to guarantee that it drops to 1% of its
+// maximum value at beta_max = 1/reg_scales for sigma = 3
+vector[K] f_beta = inv_sqrt(-2*log(0.01)*reg_scales^2) / 3;
+
+// Calculate prior scales
+// Note: Factor 0.072 is chosen such that with tau=3 the double_exponential
+// drops to 1% of its maximum value for delta_max = 1
+real<lower=0> delta_scale = 0.072*tau;
+vector[K] beta_scale = f_beta.*sigmas;

--- a/gloria/stan_models/utilities/transformed_parameters.stan
+++ b/gloria/stan_models/utilities/transformed_parameters.stan
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 e-dynamics GmbH and affiliates
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Transformer parameters shared by all models
+vector[T] trend = linear_trend(
+    k, m, delta,
+    t, A, t_change
+);

--- a/scripts/run_configs/run_config.toml
+++ b/scripts/run_configs/run_config.toml
@@ -1,5 +1,5 @@
 [model]
-model = "poisson"
+model = "negative binomial"
 sampling_period = "1d"
 timestamp_name = "ds"
 metric_name = "y"


### PR DESCRIPTION
Removed parameter bounds on the regressor coefficient parameter $\beta$ in ``priors.stan``. 

**Note**: All other parameter bounds were left unchanged in contrast to the original proposal (see #84, #98) to remove bounds from all parameters, as fits became worse with all bounds removed.

Resolves #98 